### PR TITLE
Refactor: Improve offer card layout with flex gap

### DIFF
--- a/src/components/Offer.jsx
+++ b/src/components/Offer.jsx
@@ -1,6 +1,6 @@
 export default function Offer({ elem, offset }) {
 
-    let divStyle = "max-w-[90%] w-100 p-5 sm:w-120 py-8 md:w-140 md:min-h-60 lg:min-h-90 lg:w-80 lg:p-6 lg:py-12 lg:mx-4 flex flex-col items-center justify-center bg-[#86B896] rounded-lg box-border xl:transform xl:scale-110 xl:mx-8"
+    let divStyle = "max-w-[90%] w-100 p-5 sm:w-120 py-8 md:w-140 md:min-h-60 lg:min-h-90 lg:w-1/5 lg:p-6 lg:py-12 flex flex-col items-center justify-center bg-[#86B896] rounded-lg box-border xl:transform xl:scale-110"
 
     // transition-transform duration-[1000ms] ease-in-out lg:hover:scale-115 hover:cursor z-1
 

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -82,7 +82,7 @@ export default function About() {
                     We are a vibrant community of students from the Global Challenges and Solutions Honors Program at the University of Maryland, College Park. As a branch of the university-wide Honors Ambassadors Program, our mission is to advocate for the Honors College experience and inspire prospective students to join our dynamic academic community.
                 </p>
                 <h3 className="text-center font-bold text-xl m-auto mt-35">What We Offer</h3>
-                <div className="flex flex-col lg:flex-row justify-center items-center mt-20 pb-20 lg:pb-45 ">
+                <div className="flex flex-col lg:flex-row justify-center items-center mt-20 pb-20 lg:pb-45 lg:gap-x-32">
                     {
                         offers.map((offer, index) => (
                             index == 1 ?


### PR DESCRIPTION
This commit refactors the styling for the "What We Offer" section on the About page.

The layout is updated to use the `gap` property on the parent container instead of individual margins on the `Offer` components. This provides a cleaner and more modern approach to managing space between flex items.

The width of the `Offer` component is also adjusted from a fixed value to a fractional width (`lg:w-1/5`) to ensure the cards fit correctly within the new gap-based layout on large screens.